### PR TITLE
fix: update dependency names for compatibility (underscore to dash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Call CLMM through CPI.
 [dependencies]
 anchor-lang = "=0.30.1"
 anchor-spl = "=0.30.1"
-raydium_clmm_cpi = { git = "https://github.com:raydium-io/raydium-cpi", package = "raydium-clmm-cpi", branch = "anchor-0.30.1" }
+raydium-clmm-cpi = { git = "https://github.com:raydium-io/raydium-cpi", package = "raydium-clmm-cpi", branch = "anchor-0.30.1" }
 ```
 
 Call CPMM through CPI.
@@ -20,7 +20,7 @@ Call CPMM through CPI.
 [dependencies]
 anchor-lang = "=0.30.1"
 anchor-spl = "=0.30.1"
-raydium_cpmm_cpi = { git = "https://github.com:raydium-io/raydium-cpi", package = "raydium-cpmm-cpi", branch = "anchor-0.30.1" }
+raydium-cpmm-cpi = { git = "https://github.com:raydium-io/raydium-cpi", package = "raydium-cpmm-cpi", branch = "anchor-0.30.1" }
 ```
 
 Call AMM through CPI.
@@ -28,7 +28,7 @@ Call AMM through CPI.
 [dependencies]
 anchor-lang = "=0.30.1"
 anchor-spl = "=0.30.1"
-raydium_amm_cpi = { git = "https://github.com:raydium-io/raydium-cpi", package = "raydium-amm-cpi", branch = "anchor-0.30.1" }
+raydium-amm-cpi = { git = "https://github.com:raydium-io/raydium-cpi", package = "raydium-amm-cpi", branch = "anchor-0.30.1" }
 ```
 
 You can find usage examples in this [repository](https://github.com/raydium-io/raydium-cpi-example).


### PR DESCRIPTION
PR Description:
This PR updates the names of Raydium dependencies to ensure compatibility with the current project setup. The names have been changed to follow the convention raydium-<module>-cpi instead of raydium_<module>_cpi, resolving issues encountered with dependency resolution.

Key Changes:

Updated dependency names: raydium-amm-cpi, raydium-clmm-cpi, and raydium-cpmm-cpi.
Adjusted Cargo.toml to use the new dependency names.