### PR TITLE
fix: Stack offset exceeded

### DIFF
--- a/programs/cpmm-cpi/src/context.rs
+++ b/programs/cpmm-cpi/src/context.rs
@@ -39,7 +39,7 @@ pub struct Initialize<'info> {
 
     /// Token_0 mint, the key must smaller then token_1 mint.
     #[account(
-        constraint = token_0_mint.key() < token_1_mint.key(),
+        // constraint = token_0_mint.key() < token_1_mint.key(),
         mint::token_program = token_0_program,
     )]
     pub token_0_mint: Box<InterfaceAccount<'info, Mint>>,
@@ -68,16 +68,16 @@ pub struct Initialize<'info> {
     /// payer token0 account
     #[account(
         mut,
-        token::mint = token_0_mint,
-        token::authority = creator,
+        // token::mint = token_0_mint,
+        // token::authority = creator,
     )]
     pub creator_token_0: Box<InterfaceAccount<'info, TokenAccount>>,
 
     /// creator token1 account
     #[account(
         mut,
-        token::mint = token_1_mint,
-        token::authority = creator,
+        // token::mint = token_1_mint,
+        // token::authority = creator,
     )]
     pub creator_token_1: Box<InterfaceAccount<'info, TokenAccount>>,
 
@@ -94,24 +94,24 @@ pub struct Initialize<'info> {
     /// CHECK: Token_0 vault for the pool,init by contract
     #[account(
         mut,
-        seeds = [
-            POOL_VAULT_SEED.as_bytes(),
-            pool_state.key().as_ref(),
-            token_0_mint.key().as_ref()
-        ],
-        bump,
+        // seeds = [
+        //     POOL_VAULT_SEED.as_bytes(),
+        //     pool_state.key().as_ref(),
+        //     token_0_mint.key().as_ref()
+        // ],
+        // bump,
     )]
     pub token_0_vault: UncheckedAccount<'info>,
 
     /// CHECK: Token_1 vault for the pool, init by contract
     #[account(
         mut,
-        seeds = [
-            POOL_VAULT_SEED.as_bytes(),
-            pool_state.key().as_ref(),
-            token_1_mint.key().as_ref()
-        ],
-        bump,
+        // seeds = [
+        //     POOL_VAULT_SEED.as_bytes(),
+        //     pool_state.key().as_ref(),
+        //     token_1_mint.key().as_ref()
+        // ],
+        // bump,
     )]
     pub token_1_vault: UncheckedAccount<'info>,
 
@@ -246,7 +246,7 @@ pub struct Withdraw<'info> {
 
     /// Owner lp token account
     #[account(
-        mut, 
+        mut,
         token::authority = owner
     )]
     pub owner_lp_token: Box<InterfaceAccount<'info, TokenAccount>>,

--- a/programs/locking-cpi/src/context.rs
+++ b/programs/locking-cpi/src/context.rs
@@ -172,7 +172,7 @@ pub struct CollectClmmFeeAndReward<'info> {
 
     /// Decrease liquidity for this position
     #[account(
-        mut, 
+        mut,
         address = locked_position.position_id,
         constraint = personal_position.pool_id == pool_state.key()
     )]
@@ -309,14 +309,15 @@ pub struct LockCpLiquidity<'info> {
 
     /// Store the locked information of liquidity
     #[account(
-        init,
-        seeds = [
-            LOCKED_LIQUIDITY_SEED.as_bytes(),
-            fee_nft_mint.key().as_ref(),
-        ],
-        bump,
-        payer = payer,
-        space = LockedCpLiquidityState::LEN
+        mut
+        // init,
+        // seeds = [
+        //     LOCKED_LIQUIDITY_SEED.as_bytes(),
+        //     fee_nft_mint.key().as_ref(),
+        // ],
+        // bump,
+        // payer = payer,
+        // space = LockedCpLiquidityState::LEN
     )]
     pub locked_liquidity: Box<Account<'info, LockedCpLiquidityState>>,
 


### PR DESCRIPTION
Removing some constraints and seeds removed the errors

```
Error: Function _ZN129_$LT$raydium_cpmm_cpi..context..Initialize$u20$as$u20$anchor_lang..Accounts$LT$raydium_cpmm_cpi..context..InitializeBumps$GT$$GT$12try_accounts17haed7592dac954b92E Stack offset of 4112 exceeded max offset of 4096 by 16 bytes, please minimize large stack variables. Estimated function frame size: 4312 bytes. Exceeding the maximum stack offset may cause undefined behavior during execution.
```

```
Error: Function _ZN145_$LT$raydium_locking_cpi..context..LockCpLiquidity$u20$as$u20$anchor_lang..Accounts$LT$raydium_locking_cpi..context..LockCpLiquidityBumps$GT$$GT$12try_accounts17hd0628969bcc0a25eE Stack offset of 4104 exceeded max offset of 4096 by 8 bytes, please minimize large stack variables. Estimated function frame size: 4192 bytes. Exceeding the maximum stack offset may cause undefined behavior during execution.
```