### PR TITLE
[launch-cpi] Mark signer as mutable

### DIFF
--- a/programs/launch-cpi/src/context.rs
+++ b/programs/launch-cpi/src/context.rs
@@ -152,6 +152,7 @@ pub struct Initialize<'info> {
 pub struct Swap<'info> {
     /// The user performing the swap operation
     /// Must sign the transaction and pay for fees
+    #[account(mut)]
     pub payer: Signer<'info>,
 
     /// PDA that acts as the authority for pool vault operations


### PR DESCRIPTION
Due to new launchpad update, signer is required to be writable, since it might be paying for creation of `creator_claim_fee_vault`.

Currently, there is no `mut` attribute, which breaks intended usage of CPI package.